### PR TITLE
Fix and validate release workflow pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,8 @@ on:
       - master
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,41 +10,47 @@ on:
         type: boolean
         default: false
   pull_request:
-    branches: [main, master]
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+    branches:
+      - main
+      - master
 
 concurrency:
-  group: release-${{ github.event.pull_request.head.ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   quality:
     name: Quality Check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-      with:
-        python-version: '3.12'
-    - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
-    - run: uv sync --extra dev --extra test
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      - run: uv sync --extra dev --extra test
 
-    - name: Install collections
-      uses: ./.github/actions/install-collections
+      - name: Install collections
+        uses: ./.github/actions/install-collections
 
-    - name: Run pre-commit hooks
-      env:
-        ANSIBLE_COLLECTIONS_PATH: ${{ github.workspace }}/collections
-        ANSIBLE_ROLES_PATH: ${{ github.workspace }}/roles
-      run: uv run pre-commit run --all-files --show-diff-on-failure
+      - name: Run pre-commit hooks
+        env:
+          ANSIBLE_COLLECTIONS_PATH: "${{ github.workspace }}/collections"
+          ANSIBLE_ROLES_PATH: "${{ github.workspace }}/roles"
+        run: uv run pre-commit run --all-files --show-diff-on-failure
 
-    - name: Lint Ansible code
-      env:
-        ANSIBLE_COLLECTIONS_PATH: ${{ github.workspace }}/collections
-      run: uv run ansible-lint roles/
+      - name: Lint Ansible code
+        env:
+          ANSIBLE_COLLECTIONS_PATH: "${{ github.workspace }}/collections"
+        run: uv run ansible-lint roles/
 
   release:
     name: Build & Publish
@@ -91,7 +97,7 @@ jobs:
         path: wiphoo-frp-*.tar.gz
 
     - name: Publish to Galaxy
-      if: github.event_name != 'pull_request' && (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run))
+      if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
       run: |
         FILE=$(ls -1 wiphoo-frp-*.tar.gz | head -1)
         echo "Publishing $FILE to Ansible Galaxy..."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,20 @@ jobs:
         python-version: '3.12'
     - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
     - run: uv sync --extra dev --extra test
-    - run: uv run pre-commit run --all-files --show-diff-on-failure
-    - run: uv run ansible-lint roles/
+
+    - name: Install collections
+      uses: ./.github/actions/install-collections
+
+    - name: Run pre-commit hooks
+      env:
+        ANSIBLE_COLLECTIONS_PATH: ${{ github.workspace }}/collections
+        ANSIBLE_ROLES_PATH: ${{ github.workspace }}/roles
+      run: uv run pre-commit run --all-files --show-diff-on-failure
+
+    - name: Lint Ansible code
+      env:
+        ANSIBLE_COLLECTIONS_PATH: ${{ github.workspace }}/collections
+      run: uv run ansible-lint roles/
 
   release:
     name: Build & Publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,12 @@ on:
         description: 'Dry run (build only, no publish)'
         type: boolean
         default: false
+  pull_request:
+    branches: [main, master]
+
+concurrency:
+  group: release-${{ github.event.pull_request.head.ref || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -85,7 +91,7 @@ jobs:
         path: wiphoo-frp-*.tar.gz
 
     - name: Publish to Galaxy
-      if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
+      if: github.event_name != 'pull_request' && (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run))
       run: |
         FILE=$(ls -1 wiphoo-frp-*.tar.gz | head -1)
         echo "Publishing $FILE to Ansible Galaxy..."


### PR DESCRIPTION
## Summary
- align the release workflow quality job with main CI by installing the required Ansible collections before running pre-commit and ansible-lint
- validate the release workflow on pull requests with explicit PR event types and workflow-level concurrency
- avoid canceling in-flight release and manual dispatch runs while still canceling superseded pull request validations
- keep publish restricted to release and non-dry-run manual dispatches

## Testing
- UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/ --tb=no -q
- PRE_COMMIT_HOME=/tmp/pre-commit-cache UV_CACHE_DIR=/tmp/uv-cache PIP_INDEX_URL=https://pypi.org/simple PIP_EXTRA_INDEX_URL= uv run pre-commit run --all-files --show-diff-on-failure
- UV_CACHE_DIR=/tmp/uv-cache uv run yamllint .github/workflows/release.yml
- ANSIBLE_COLLECTIONS_PATH=/home/terng/work/personal/wiphoo_ansible_frp/collections UV_CACHE_DIR=/tmp/uv-cache uv run ansible-lint roles/